### PR TITLE
Exported `KnownBrowsers` & `KnownPlatforms` dictionaries in `types` declaration

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,4 @@
-declare const KnownBrowsers: {
+export declare const KnownBrowsers: {
   chrome: string;
   brave: string;
   crios: string;
@@ -18,7 +18,7 @@ declare const KnownBrowsers: {
   electron: string;
 };
 
-declare const KnownPlatforms: {
+export declare const KnownPlatforms: {
   android: string;
   androidTablet: string;
   cros: string;


### PR DESCRIPTION
This PR addresses the https://github.com/sibiraj-s/browser-dtector/issues/11 issue.

I exported both the `KnownBrowsers` and `KnownPlatforms` variables in the `TS` definition to be able to write comparisons properly in TS projects w/o the next error:
![image](https://github.com/sibiraj-s/browser-dtector/assets/68850090/728ad272-4166-4e87-b9f7-8a3766f0e575)