### PR TITLE
fix(types): fix name and platform types

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -39,8 +39,8 @@ export type KnownBrowsersKeys = keyof typeof KnownBrowsers;
 export type KnownPlatformsKeys = keyof typeof KnownPlatforms;
 
 export interface BrowserInfo {
-  name: ValueOf<KnownBrowsersKeys> | null;
-  platform: ValueOf<KnownPlatformsKeys> | null;
+  name: ValueOf<typeof KnownBrowsers> | null;
+  platform: ValueOf<typeof KnownPlatforms> | null;
   userAgent: string;
   version: string | null;
   shortVersion: string | null;


### PR DESCRIPTION
This fixes the type of `parseUserAgent().name` which is currently plain wrong: `ValueOf<KnownBrowsersKeys>` essentially unwraps to `string[keyof string]` which is the set of types of properties that strings have (such as number, Symbol iterator, "charAt", etc.)

In user-land code, it's then not possible to assign `name` to `string | null`.